### PR TITLE
[Feat] #4 - 태그, 검색 터치시 상세뷰 이동

### DIFF
--- a/EasyVel.xcodeproj/project.pbxproj
+++ b/EasyVel.xcodeproj/project.pbxproj
@@ -31,6 +31,7 @@
 		87DC479E2A59B1F6007823CB /* SignInUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87DC479D2A59B1F6007823CB /* SignInUseCase.swift */; };
 		87F25EEB2A84385800E03C32 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F25EEA2A84385800E03C32 /* Config.swift */; };
 		87F25EF22A844EE100E03C32 /* VoidDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F25EF12A844EE100E03C32 /* VoidDTO.swift */; };
+		87F287EC2A9DE2A300A53218 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87F287EB2A9DE2A300A53218 /* UIViewController+.swift */; };
 		910950522A4F155F00D04D41 /* CurrentSearchDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 910950512A4F155F00D04D41 /* CurrentSearchDTO.swift */; };
 		910950582A50117F00D04D41 /* VersionCheckDTO.swift in Sources */ = {isa = PBXBuildFile; fileRef = 910950572A50117F00D04D41 /* VersionCheckDTO.swift */; };
 		9109505A2A5011DD00D04D41 /* VersionTargetType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 910950592A5011DD00D04D41 /* VersionTargetType.swift */; };
@@ -207,6 +208,7 @@
 		87F25EE92A84363C00E03C32 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		87F25EEA2A84385800E03C32 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		87F25EF12A844EE100E03C32 /* VoidDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoidDTO.swift; sourceTree = "<group>"; };
+		87F287EB2A9DE2A300A53218 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		910950512A4F155F00D04D41 /* CurrentSearchDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentSearchDTO.swift; sourceTree = "<group>"; };
 		910950572A50117F00D04D41 /* VersionCheckDTO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionCheckDTO.swift; sourceTree = "<group>"; };
 		910950592A5011DD00D04D41 /* VersionTargetType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VersionTargetType.swift; sourceTree = "<group>"; };
@@ -839,6 +841,7 @@
 				8765EFF32A29ECDE00EF6733 /* String+Extension.swift */,
 				916227D72A44569500118018 /* UITextField+Extension.swift */,
 				87DC47892A560857007823CB /* UIApplication+Extension.swift */,
+				87F287EB2A9DE2A300A53218 /* UIViewController+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -1315,6 +1318,7 @@
 				914D8DD92A02B22A00516B4C /* WebViewController.swift in Sources */,
 				91487F5929FDA269009CFECF /* PostsTableViewCell.swift in Sources */,
 				91ED17892A00E58D00158787 /* SubscriberService.swift in Sources */,
+				87F287EC2A9DE2A300A53218 /* UIViewController+.swift in Sources */,
 				9128B0562A23CC7400FB1252 /* ScrapStorageViewController.swift in Sources */,
 				91487F3729FD88E7009CFECF /* SubscriberViewController.swift in Sources */,
 				91A052132A28F9E6009F32D1 /* ScrapFolder.swift in Sources */,

--- a/EasyVel/Presentation/Posts/KeywordPostsVCFactory.swift
+++ b/EasyVel/Presentation/Posts/KeywordPostsVCFactory.swift
@@ -11,14 +11,17 @@ final class KeywordPostsVCFactory {
     
     // MARK: - home에서 ViewController 만들 때 사용
     
-    func create(
-        tag: String
-    ) -> PostsViewController {
-        let vc = PostsViewController(
-            viewModel: PostsViewModel(viewType: .keyword, tag: tag, service: DefaultPostService.shared)
-        )
+    func create(tag: String,
+                isNavigationBarHidden: Bool = true) -> PostsViewController {
+        let vc = PostsViewController(viewModel: PostsViewModel(viewType: .keyword,
+                                                               tag: tag,
+                                                               service: DefaultPostService.shared),
+                                     isNavigationBarHidden: isNavigationBarHidden)
+        vc.title = tag
         return vc
     }
+    
+    
     
     // MARK: - search tagPost에서 ViewController 만들 때 사용
     

--- a/EasyVel/Presentation/Posts/PostsViewController.swift
+++ b/EasyVel/Presentation/Posts/PostsViewController.swift
@@ -24,6 +24,12 @@ final class PostsViewController: RxBaseViewController<PostsViewModel> {
         super.init(viewModel: viewModel)
     }
     
+    init(viewModel: PostsViewModel,
+         isNavigationBarHidden: Bool) {
+        super.init(viewModel: viewModel)
+        self.isNavigationBarHidden = isNavigationBarHidden
+    }
+    
     init(
         viewModel: PostsViewModel,
         isNavigationBarHidden: Bool,

--- a/EasyVel/Presentation/Search/PostSearch/PostSearchViewController.swift
+++ b/EasyVel/Presentation/Search/PostSearch/PostSearchViewController.swift
@@ -30,7 +30,6 @@ final class PostSearchViewController: RxBaseViewController<PostSearchViewModel> 
     private lazy var recentSearchTagCollectionView = UICollectionView(frame: .zero, collectionViewLayout: flowLayout)
     
     private let popularSearchTagTableView = UITableView()
-    private let tapGesture = UITapGestureRecognizer()
     private let searchBar = UISearchBar(frame: CGRect(x: 0, y: 0, width: 280, height: 0))
     
     
@@ -82,8 +81,7 @@ final class PostSearchViewController: RxBaseViewController<PostSearchViewModel> 
         
         setTableView()
         setCollectionView()
-        setTagGesture()
-        setKeyBoardNotification()
+        //dismissKeyboardWhenTappedAround()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -161,12 +159,6 @@ final class PostSearchViewController: RxBaseViewController<PostSearchViewModel> 
             })
             .disposed(by: disposeBag)
         
-        tapGesture.rx.event
-            .subscribe(onNext: { [weak self] _ in
-                self?.searchBar.resignFirstResponder()
-            })
-            .disposed(by: disposeBag)
-        
         deleteButton.rx.tap
             .subscribe(onNext: { [weak self] _ in
                 self?.viewModel?.deleteAllCurrentSearchTagInput.accept(Void())
@@ -227,10 +219,6 @@ final class PostSearchViewController: RxBaseViewController<PostSearchViewModel> 
         return viewController
     }
     
-    private func setTagGesture() {
-        view.addGestureRecognizer(tapGesture)
-    }
-    
     private func setEmptyRecentSearchTagExcaptionLabel(
         isCurrentSearchTagListEmpty: Bool
     ) {
@@ -285,6 +273,12 @@ extension PostSearchViewController: UITableViewDataSource, UITableViewDelegate {
         cell.configCell(self.popularSearchTagList[indexPath.row], indexPath.row + 1)
         return cell
     }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        let tag = popularSearchTagList[indexPath.row]
+        let postsVC = KeywordPostsVCFactory().create(tag: tag, isNavigationBarHidden: false)
+        navigationController?.pushViewController(postsVC, animated: true)
+    }
 }
 
 extension PostSearchViewController: UICollectionViewDelegate, UICollectionViewDataSource {
@@ -299,34 +293,6 @@ extension PostSearchViewController: UICollectionViewDelegate, UICollectionViewDa
         cell.configCell(currentSearchTagList[indexPath.row])
         return cell
     }
-}
-
-// MARK: - keyboard height
-
-extension PostSearchViewController {
-    private func setKeyBoardNotification() {
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(keyboardWillShow),
-            name: UIResponder.keyboardWillShowNotification,
-            object: nil
-        )
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(self.keyboardWillHide),
-            name: UIResponder.keyboardWillHideNotification, object: nil
-        )
-    }
     
-    @objc
-    func keyboardWillShow(_ notification: Notification) {
-        if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
-            let keyboardRectangle = keyboardFrame.cgRectValue
-            keyboardHeight = keyboardRectangle.height
-        }
-    }
     
-    @objc func keyboardWillHide(_ notification: Notification) {
-        keyboardHeight = 0.0
-    }
 }

--- a/EasyVel/Presentation/Search/TagSearch/TagSearchViewController.swift
+++ b/EasyVel/Presentation/Search/TagSearch/TagSearchViewController.swift
@@ -134,7 +134,8 @@ final class TagSearchViewController: RxBaseViewController<TagSearchViewModel> {
         let input = TagSearchViewModel.Input(
             searchBarDidEditEvent: searchBar.searchTextField.rx.text.orEmpty.asObservable(),
             searchTextFieldDidEnd: searchBar.searchTextField.rx.controlEvent(.editingDidEnd).asObservable(),
-            myTagCellDidTap: myTagCollectionView.rx.modelSelected(String.self).asObservable()
+            myTagCellDidTap: myTagCollectionView.rx.modelSelected(String.self).asObservable(),
+            popularTagCellDidTap: popularTagTableView.rx.modelSelected(String.self).asObservable()
         )
         
         viewModel.transform(input)
@@ -180,6 +181,15 @@ final class TagSearchViewController: RxBaseViewController<TagSearchViewModel> {
                 let alertVC = VelogAlertViewController(alertType: .deleteTag,
                                                        delegate: self)
                 self.present(alertVC, animated: false)
+            }
+            .disposed(by: disposeBag)
+        
+        viewModel.presentTagPostsViewController
+            .asDriver(onErrorJustReturn: String())
+            .drive { [weak self] tag in
+                guard let self else { return }
+                let postsVC = KeywordPostsVCFactory().create(tag: tag, isNavigationBarHidden: false)
+                navigationController?.pushViewController(postsVC, animated: true)
             }
             .disposed(by: disposeBag)
         

--- a/EasyVel/Presentation/Search/TagSearch/TagSearchViewModel.swift
+++ b/EasyVel/Presentation/Search/TagSearch/TagSearchViewModel.swift
@@ -40,6 +40,7 @@ final class TagSearchViewModel: BaseViewModel {
         var searchBarDidEditEvent: Observable<String>
         var searchTextFieldDidEnd: Observable<Void>
         var myTagCellDidTap: Observable<String>
+        var popularTagCellDidTap: Observable<String>
     }
 
     // MARK: - Output
@@ -48,6 +49,7 @@ final class TagSearchViewModel: BaseViewModel {
     var popularTagsOutput = BehaviorRelay<[String]>(value: Array<String>(repeating: "", count: 10))
     
     var presentDeleteMyTagAlertOutput = PublishRelay<Bool>()
+    var presentTagPostsViewController = PublishRelay<String>()
     
     var tagAddStatusOutput = PublishRelay<(Bool, String)>()
     var deleteTagStatusOutPut = PublishRelay<(Bool, String)>()
@@ -99,6 +101,12 @@ final class TagSearchViewModel: BaseViewModel {
             .subscribe { [weak self] tag in
                 self?.deleteTag = tag
                 self?.presentDeleteMyTagAlertOutput.accept(true)
+            }
+            .disposed(by: disposeBag)
+        
+        input.popularTagCellDidTap
+            .subscribe { [weak self] tag in
+                self?.presentTagPostsViewController.accept(tag)
             }
             .disposed(by: disposeBag)
         

--- a/EasyVel/Util/Extension/UIViewController+.swift
+++ b/EasyVel/Util/Extension/UIViewController+.swift
@@ -1,0 +1,26 @@
+//
+//  UIViewController+.swift
+//  EasyVel
+//
+//  Created by 장석우 on 2023/08/29.
+//
+
+import UIKit
+
+extension UIViewController {
+    func dismissKeyboardWhenTappedAround() {
+        print(#function)
+        let tap: UITapGestureRecognizer = UITapGestureRecognizer(target: self,
+                                                                 action: #selector(self.dismissKeyboard))
+        tap.cancelsTouchesInView = true
+        self.view.addGestureRecognizer(tap)
+    }
+    
+    @objc func dismissKeyboard() {
+        self.view.endEditing(true)
+    }
+    
+    open override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?){
+          dismissKeyboard()
+    }
+}


### PR DESCRIPTION
## 📌 Summary
인기 태그, 인기 검색어 선택시 해당 Post뷰로 이동하도록 구현하였습니다.

## ✍️ Description
- 이슈 티켓 : #4
인기검색어 쪽에서 키보드 내리기용 터치 와 인기검색어 TableView Cell 터치가 중첩되어 제대로 동작하지 않습니다.
현재는 키보드 내리기용 터치를 포기하고 Cell 터치만 되도록 구현했습니다.
추후 둘다 터치되도록 해결하게씃빈당

## 🔥 Test
- 

closed: #4 
