### PR TITLE
[FEAT] #33 - 스크랩 폴더 삭제 기능 연결

### DIFF
--- a/EasyVel/Presentation/Scrap/Storage/View/StorageCollectionViewHeader.swift
+++ b/EasyVel/Presentation/Scrap/Storage/View/StorageCollectionViewHeader.swift
@@ -20,7 +20,7 @@ final class StorageCollectionViewHeader: UICollectionReusableView {
         return self.changeNameButton.rx.tap.asDriver()
     }
     
-    var deleteFolderButtonTrigger: Driver<Void> {
+    var showBottomSheetTrigger: Driver<Void> {
         return self.deleteFolderButton.rx.tap.asDriver()
     }
     

--- a/EasyVel/Presentation/Scrap/Storage/View/StoragePostView.swift
+++ b/EasyVel/Presentation/Scrap/Storage/View/StoragePostView.swift
@@ -146,24 +146,6 @@ extension StoragePostView {
     }
 }
 
-//extension NewStoragePostView {
-//    
-//    func configureCollectionView(with title: String) {
-//        self.collectionView.collectionViewLayout = createLayout()
-//        self.collectionView.register(
-//            StorageCollectionViewHeader.self,
-//            forSupplementaryViewOfKind: UICollectionView.elementKindSectionHeader,
-//            withReuseIdentifier: StorageCollectionViewHeader.reuseIdentifier
-//        )
-//    }
-//}
-
-//extension NewStoragePostView {
-//    func showEmptyView() {
-//        self.emptyImageView.isHidden = false
-//    }
-//}
-
 extension StoragePostView {
     
     func createLayout() -> UICollectionViewLayout {

--- a/EasyVel/Presentation/Scrap/Storage/ViewController/StorageViewController.swift
+++ b/EasyVel/Presentation/Scrap/Storage/ViewController/StorageViewController.swift
@@ -66,10 +66,6 @@ final class StorageViewController: BaseViewController {
     
     // MARK: - Setting
     
-    override func render() {}
-    
-    override func configUI() {}
-    
     private func bind() {
         self.storageView.backButton.rx.tap
             .subscribe(onNext: {
@@ -133,6 +129,11 @@ final class StorageViewController: BaseViewController {
         output.showChangeNameAlert
             .drive(with: self) { owner, folderName in
                 owner.showChageFolderNameAlert(folderName: folderName)
+            }.disposed(by: self.disposeBag)
+        
+        header.showBottomSheetTrigger
+            .drive(with: self) { owner, _ in
+                owner.storageView.showDeleteFolderBottomSheet()
             }.disposed(by: self.disposeBag)
     }
     
@@ -244,5 +245,6 @@ extension StorageViewController {
 extension StorageViewController: FolderViewControllerDelegate {
     func folderVCDismiss(newFolderName: String) {
         self.storageView.updateTitle(to: newFolderName)
+        self.viewModel.updateFolderName(to: newFolderName)
     }
 }

--- a/EasyVel/Presentation/Scrap/Storage/ViewModel/StorageViewModel.swift
+++ b/EasyVel/Presentation/Scrap/Storage/ViewModel/StorageViewModel.swift
@@ -140,3 +140,9 @@ extension StorageViewModel {
         return self.realm.deleteFolder(folderName: name)
     }
 }
+
+extension StorageViewModel {
+    func updateFolderName(to name: String) {
+        self.folderName = name
+    }
+}


### PR DESCRIPTION
## 📌 Summary
<!— PR 요약을 써주세요. —>
업데이트 전에 연결해두었어야 했는데 ... 
폴더 삭제 기능을 연결 못했던걸 이제서야 합니다 ㅎㅎ;;

## ✍️ Description
<!— PR에 대한 자세한 설명을 써주세요. —>
- 이슈 티켓 : #33 

예전에 잘 만들어 둔 UI 연결하고 액션만 연결하니까 금방 하네요 ~

다만 조금 이슈가 있었던게,
폴더 이름 변경 -> 바로 폴더 삭제
순서로 진행하면 폴더가 잘 삭제되지 않았는데,
그 이유가 폴더 이름이 바뀔 때 ViewModel 에 있는 folderName 프로퍼티 값이 업데이트 되지 않았기 때문입니다 !

지금 정은이가 잘 만들어준 FolderAlertViewController 로 realm 에 이름 변경은 잘 되는데,
FolderAlertViewController 가 새로운 ViewController 이기 때문에 기존 StorageViewModel 로 이벤트를 전달하기 어렵습니닷 ..
그래서 이벤트 전달하는 Input Output 관계를 두지 않고, viewmodel 에 public 함수를 두고 변경하는 식으로 적용했습니다..!!

## 🔥 Test
<!— Test —>
